### PR TITLE
Switching to no-numbered to patch generation

### DIFF
--- a/lib/tetra/facades/git.rb
+++ b/lib/tetra/facades/git.rb
@@ -161,7 +161,7 @@ module Tetra
     # since from_id
     def format_patch(directory, from_id, destination_path)
       Dir.chdir(@directory) do
-        run("git format-patch -o #{destination_path} --numbered #{from_id} -- #{directory}").split
+        run("git format-patch -o #{destination_path} --no-numbered #{from_id} -- #{directory}").split
       end
     end
   end


### PR DESCRIPTION
The --numbered argument for git lets git create patches with
numbers (e.g. [1/3]) in the patch subject. This leads to changes in
the previous patches when adding a new patch.

With --no-numbered git always generates exactly the same patch,
independend from the amount of patches created after it.