### PR TITLE
Make it possible to do scripted dry-runs

### DIFF
--- a/lib/tetra/facades/bash.rb
+++ b/lib/tetra/facades/bash.rb
@@ -12,7 +12,7 @@ module Tetra
 
     # runs bash in a subshell, returns list of
     # commands that were run in the session
-    def bash
+    def bash(command = nil)
       Tempfile.open("tetra-history") do |history_file|
         Tempfile.open("tetra-bashrc") do |bashrc_file|
           kit = Tetra::Kit.new(@project)
@@ -31,12 +31,17 @@ module Tetra
           bashrc_file.write(bashrc_content)
           bashrc_file.flush
 
-          run_interactive("bash --rcfile #{bashrc_file.path} -i")
-          history = File.read(history_file)
-          log.debug "history contents:"
-          log.debug history
+          if command
+            run("bash --rcfile #{bashrc_file.path} -i -c '#{command}'")
+            [command]
+          else
+            run_interactive("bash --rcfile #{bashrc_file.path} -i")
+            history = File.read(history_file)
+            log.debug "history contents:"
+            log.debug history
 
-          history.split("\n").map(&:strip)
+            history.split("\n").map(&:strip)
+          end
         end
       end
     end

--- a/lib/tetra/ui/dry_run_subcommand.rb
+++ b/lib/tetra/ui/dry_run_subcommand.rb
@@ -3,6 +3,7 @@
 module Tetra
   # tetra dry-run
   class DryRunSubcommand < Tetra::Subcommand
+    option ["-s", "--script"], "SCRIPT", "Run these commands to build the project instead of the interactive shell"
     def execute
       checking_exceptions do
         project = Tetra::Project.new(".")
@@ -14,13 +15,17 @@ module Tetra
           puts "Dry run not started."
         else
           project.dry_run
-          puts "Dry-run started in a new bash shell."
-          puts "Build your project now, \"mvn\" and \"ant\" are already bundled by tetra."
-          puts "If the build succeedes end this dry run with ^D (Ctrl+D),"
-          puts "if the build does not succeed use ^C^D to abort and undo any change"
+          if script
+            puts "Scripted dry-run started."
+          else
+            puts "Dry-run started in a new bash shell."
+            puts "Build your project now, \"mvn\" and \"ant\" are already bundled by tetra."
+            puts "If the build succeedes end this dry run with ^D (Ctrl+D),"
+            puts "if the build does not succeed use ^C^D to abort and undo any change"
+          end
 
           begin
-            history = Tetra::Bash.new(project).bash
+            history = Tetra::Bash.new(project).bash(script)
             project.finish(history)
             puts "Dry-run finished"
           rescue ExecutionFailed

--- a/spec/lib/coarse/dry_run_subcommand_spec.rb
+++ b/spec/lib/coarse/dry_run_subcommand_spec.rb
@@ -17,6 +17,7 @@ describe "`tetra dry-run`", type: :aruba do
     type("\u{0004}") # ^D (Ctrl+D), terminates bash with exit status 0
 
     expect(all_output).to include("Dry-run started")
+    expect(all_output).to include("bash shell")
     expect(all_output).to include("ciao")
     expect(all_output).to include("Dry-run finished")
 
@@ -27,5 +28,22 @@ describe "`tetra dry-run`", type: :aruba do
     run_simple("git rev-list --format=%B --max-count=1 HEAD")
     expect(stdout_from("git rev-list --format=%B --max-count=1 HEAD")).to include("tetra: dry-run-finished")
     expect(stdout_from("git rev-list --format=%B --max-count=1 HEAD")).to include("tetra: build-script-line: echo ciao")
+  end
+
+  it "does a scripted dry-run" do
+    run_simple("tetra init --no-archive mypackage")
+    cd("mypackage")
+
+    run_interactive("tetra dry-run -s 'echo ciao > ciao.jar'")
+
+    expect(all_output).to include("Scripted dry-run started")
+
+    # check that markers were written in git repo
+    run_simple("git rev-list --format=%B --max-count=1 HEAD~")
+    expect(stdout_from("git rev-list --format=%B --max-count=1 HEAD~")).to include("tetra: dry-run-started")
+
+    run_simple("git rev-list --format=%B --max-count=1 HEAD")
+    expect(stdout_from("git rev-list --format=%B --max-count=1 HEAD")).to include("tetra: dry-run-finished")
+    expect(stdout_from("git rev-list --format=%B --max-count=1 HEAD")).to include("tetra: build-script-line: echo ciao > ciao.jar")
   end
 end


### PR DESCRIPTION
The `dry-run` subcommand now takes an optional `--script` parameter which
makes the dry-run non-interactive and thus allows for automating tetra
where needed.